### PR TITLE
Fix Token Holder List Query

### DIFF
--- a/frontend/src/app/view-token/view-token.page.ts
+++ b/frontend/src/app/view-token/view-token.page.ts
@@ -169,6 +169,9 @@ export class ViewTokenPage implements OnInit {
         {
           offset: 0,
           limit: 100,
+          order_by: {
+            amount: "desc_nulls_last"
+          },
           where: {
             token_id: {
               _eq: this.token.id


### PR DESCRIPTION
Adds an `order_by` to GraphQL query so whales show up first even if they are >100th minter. 