### PR TITLE
feat: show token icons on markets pages

### DIFF
--- a/frontend/src/app/markets/markets.page.html
+++ b/frontend/src/app/markets/markets.page.html
@@ -41,6 +41,7 @@
             </ng-template>
             <ng-template pTemplate="header">
               <tr>
+                <th>&nbsp;</th>
                 <th pSortableColumn="ticker" pFrozenColumn>Market <p-sortIcon field="ticker"></p-sortIcon></th>
                 <th pSortableColumn="name">Token <p-sortIcon field="name"></p-sortIcon></th>
                 <th>Listings</th>
@@ -51,6 +52,13 @@
             </ng-template>
             <ng-template pTemplate="body" let-token>
               <tr [routerLink]="['/app/market', token.ticker]">
+                <td class="token-logo">
+                  <div class="image">
+                    <img [src]="token.content_path" *ngIf="token.content_path" />
+                    <img class="no-logo" src="../../assets/logo/a-white-on-transparent-250.png"
+                      *ngIf="!token.content_path" />
+                  </div>
+                </td>
                 <td pFrozenColumn>{{ token.ticker }} / ATOM</td>
                 <td>{{ token.name }}</td>
                 <td class="mono">{{ token.marketplace_cft20_details.length }}</td>

--- a/frontend/src/app/trade-token-v2/trade-token-v2.page.html
+++ b/frontend/src/app/trade-token-v2/trade-token-v2.page.html
@@ -9,7 +9,12 @@
               <ion-back-button defaultHref="/app/markets"></ion-back-button>
             </ion-buttons>
             <ion-title>
-              <span *ngIf="!isLoading">{{ token.ticker }}</span> / ATOM Market
+              <span class="token-logo" *ngIf="token?.content_path">
+                <span class="image">
+                  <img [src]="token.content_path"  />
+                </span>
+              </span>
+              <span *ngIf="token">{{ token.ticker }}</span> / ATOM Market
             </ion-title>
           </ion-toolbar>
         </ion-header>

--- a/frontend/src/app/trade-token-v2/trade-token-v2.page.scss
+++ b/frontend/src/app/trade-token-v2/trade-token-v2.page.scss
@@ -64,3 +64,12 @@ h1 {
         color: rgba(255, 255, 255, 0.6);
     }
 }
+
+ion-title {
+    .token-logo img {
+        width: 40px;
+        height: 40px;
+        border-radius: 7px;
+        margin-right: 10px;
+    }
+}

--- a/frontend/src/app/view-token/view-token.page.scss
+++ b/frontend/src/app/view-token/view-token.page.scss
@@ -35,10 +35,3 @@ h1 {
     text-align: left;
     background-color: rgba(0, 0, 0, 0.1);
 }
-
-
-
-.no-logo {
-    opacity: 0.7;
-
-}

--- a/frontend/src/app/wallet-token/wallet-token.page.scss
+++ b/frontend/src/app/wallet-token/wallet-token.page.scss
@@ -37,11 +37,6 @@ h1 {
     border-radius: 10px;
 }
 
-.no-logo {
-    opacity: 0.7;
-
-}
-
 .history {
     margin-left: 0;
     // max-width: 900px;

--- a/frontend/src/app/wallet/wallet.page.scss
+++ b/frontend/src/app/wallet/wallet.page.scss
@@ -35,7 +35,6 @@
         img.no-logo {
             max-width: 25%;
             padding-top: 30px;
-            opacity: 0.7;
         }
     }
 }

--- a/frontend/src/theme/base.scss
+++ b/frontend/src/theme/base.scss
@@ -431,6 +431,7 @@ p-table {
         &.no-logo {
           padding-top: 5px;
           max-width: 30px;
+          opacity: 0.7;
         }
       }
     }


### PR DESCRIPTION
shows token icons on markets pages

before:

<img width="660" src="https://github.com/astroport-fi/asteroid-protocol/assets/156972127/a5ca2ec4-78db-4fb1-9e63-442e2e6aa2f8">

<img width="386" alt="Screenshot 2024-01-27 at 10 50 25 PM" src="https://github.com/astroport-fi/asteroid-protocol/assets/156972127/35ab735a-9fd2-4669-9ad4-fdae745af7ca">

after:
<img width="668"  src="https://github.com/astroport-fi/asteroid-protocol/assets/156972127/e541d5cc-4ca6-46c6-9045-79ab2da7a2f9">

<img width="384"  src="https://github.com/astroport-fi/asteroid-protocol/assets/156972127/50269bdf-4134-4a7e-bec0-d10ab8b74338">


also moves `no-logo` css to base