### PR TITLE
fix: display newlines in inscription description

### DIFF
--- a/frontend/src/app/view-inscription/view-inscription.page.scss
+++ b/frontend/src/app/view-inscription/view-inscription.page.scss
@@ -1,28 +1,32 @@
 h1 {
-    font-size: 36px;
+  font-size: 36px;
 }
 
 .meta {
-    .label {
-        font-size: 14px;
-        color: #dddddd;
-        font-weight: 600;
-        display: block;
-    }
+  .label {
+    font-size: 14px;
+    color: #dddddd;
+    font-weight: 600;
+    display: block;
+  }
 
-    .value {
-        font-size: 14px;
-        color: #ffffff;
-        font-weight: normal;
-        display: block;
-    }
+  .value {
+    font-size: 14px;
+    color: #ffffff;
+    font-weight: normal;
+    display: block;
+  }
 
-    a {
-        color: var(--color-teal);
-    }
+  a {
+    color: var(--color-teal);
+  }
 }
 
 .is-owner {
-    text-align: left;
-    background-color: rgba(0, 0, 0, 0.1);
+  text-align: left;
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.note {
+  white-space: pre-wrap;
 }


### PR DESCRIPTION
Users like to put stories to inscription description as part of the inscription and they need to have ways how to visually separate content. This is a quick fix to support new lines in a description, but we can improve it in the future with markdown support.

New lines are stored, but not displayed, the PR fixes it