### PR TITLE
@asteroid-protocol/sdk 0.5.0

### DIFF
--- a/client/.eslintignore
+++ b/client/.eslintignore
@@ -1,1 +1,4 @@
 example
+src/zeus/**/*.ts
+cjs
+esm

--- a/client/README.md
+++ b/client/README.md
@@ -23,9 +23,10 @@ SKD exposes Operations class for each metaprotocol and calling a metaprotocol op
 
 - `MarketplaceOperations`
   - `listCFT20(ticker: string, amount: number, pricePerToken: number, minDepositPercent: number, timeoutBlocks: number): TxData`
+  - `listInscription(hash: string, price: number, minDepositPercent: number, timeoutBlocks: number): TxData`
   - `delist(listingHash: string): TxData`
   - `deposit(listingHash: string): TxData`
-  - `buyCFT20(listingHash: string): TxData`
+  - `buy(listingHash: string, buyType: 'cft20' | 'inscription'): TxData`
 
 ### Tx Data interface
 
@@ -296,6 +297,23 @@ Options:
   -h, --help                       display help for command
 ```
 
+#### List Inscription
+
+```bash
+Usage: asteroid marketplace list inscription [options]
+
+Creating a new listing for an inscription
+
+Options:
+  -n, --network <NETWORK_NAME>     Name of the network to use (default: "local")
+  -a, --account <ACCOUNT_NAME>     Name of the account to use as transaction signer
+  -t, --hash <HASH>                The transaction hash containing the inscription
+  -p, --price <PRICE>              The price in atom
+  -d, --min-deposit <MIN_DEPOSIT>  The minimum deposit expressed as a percentage of total (default: "10")
+  -b, --timeout-blocks <DECIMALS>  The block this reservation expires (default: "50")
+  -h, --help                       display help for command
+```
+
 #### Deposit
 
 ```bash
@@ -314,6 +332,20 @@ Options:
 
 ```bash
 Usage: asteroid marketplace buy cft20 [options]
+
+Buy a listing, the listing must be reserved first
+
+Options:
+  -n, --network <NETWORK_NAME>  Name of the network to use (default: "local")
+  -a, --account <ACCOUNT_NAME>  Name of the account to use as transaction signer
+  -h, --hash <HASH>             The listing transaction hash
+  --help                        display help for command
+```
+
+#### Buy Inscription
+
+```bash
+Usage: asteroid marketplace buy inscription [options]
 
 Buy a listing, the listing must be reserved first
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asteroid-protocol/sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asteroid-protocol/sdk",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@cosmjs/crypto": "^0.32.2",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asteroid-protocol/sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "scripts": {

--- a/client/src/metaprotocol/cft20.ts
+++ b/client/src/metaprotocol/cft20.ts
@@ -1,10 +1,10 @@
 import {
   BaseProtocol,
-  Inscription,
+  InscriptionContent,
   MetaProtocol,
   MetaProtocolParams,
   ProtocolFee,
-  buildInscription,
+  buildInscriptionContent,
   buildOperation,
 } from './index.js'
 import { InscriptionMetadata } from './inscription.js'
@@ -36,7 +36,7 @@ export default class CFT20Protocol
     accountAddress: string,
     data: string | Buffer,
     mime: string,
-  ): Inscription {
+  ): InscriptionContent {
     const inscriptionMetadata: InscriptionMetadata = {
       parent: {
         type: '/cosmos.bank.Account',
@@ -49,7 +49,7 @@ export default class CFT20Protocol
       },
     }
 
-    return buildInscription(data, inscriptionMetadata)
+    return buildInscriptionContent(data, inscriptionMetadata)
   }
 
   deploy(

--- a/client/src/metaprotocol/index.ts
+++ b/client/src/metaprotocol/index.ts
@@ -8,7 +8,7 @@ export interface MetaProtocol {
 
 export type MetaProtocolParams = Array<[string, string | number]>
 
-export interface Inscription {
+export interface InscriptionContent {
   data: string // data base64
   metadata: string // metadata base64
   hash: string
@@ -82,10 +82,10 @@ export function buildOperation(
   }
 }
 
-export function buildInscription(
+export function buildInscriptionContent(
   data: string | Buffer,
   metadata: unknown,
-): Inscription {
+): InscriptionContent {
   let dataStr: string
   if (Buffer.isBuffer(data)) {
     dataStr = data.toString('base64')

--- a/client/src/metaprotocol/inscription.ts
+++ b/client/src/metaprotocol/inscription.ts
@@ -1,9 +1,9 @@
 import {
   BaseProtocol,
-  Inscription,
+  InscriptionContent,
   MetaProtocolParams,
   ProtocolFee,
-  buildInscription,
+  buildInscriptionContent,
   buildOperation,
 } from './index.js'
 
@@ -46,17 +46,17 @@ export default class InscriptionProtocol extends BaseProtocol {
     super(chainId, fee)
   }
 
-  createInscription<T = ContentMetadata>(
+  createInscriptionContent<T = ContentMetadata>(
     data: string | Buffer,
     metadata: T,
     parent: Parent,
-  ): Inscription {
+  ): InscriptionContent {
     const inscriptionMetadata: InscriptionMetadata<T> = {
       parent,
       metadata,
     }
 
-    return buildInscription(data, inscriptionMetadata)
+    return buildInscriptionContent(data, inscriptionMetadata)
   }
 
   inscribe(hash: string) {

--- a/client/src/metaprotocol/marketplace.ts
+++ b/client/src/metaprotocol/marketplace.ts
@@ -14,8 +14,14 @@ const DEFAULT_FEE: ProtocolFee = {
       amount: '0.02', // Default 2%
       type: 'dynamic-percent',
     },
+    'buy.inscription': {
+      amount: '0.02', // Default 2%
+      type: 'dynamic-percent',
+    },
   },
 }
+
+export type BuyType = 'cft20' | 'inscription'
 
 export default class MarketplaceProtocol extends BaseProtocol {
   version = 'v1'
@@ -50,7 +56,7 @@ export default class MarketplaceProtocol extends BaseProtocol {
   ) {
     const params: MetaProtocolParams = [
       ['h', hash],
-      ['total', amount],
+      ['amt', amount],
       ['mindep', minDeposit],
       ['to', timeoutBlocks],
     ]
@@ -73,8 +79,14 @@ export default class MarketplaceProtocol extends BaseProtocol {
     return buildOperation(this, this.fee, this.chainId, 'delist', params)
   }
 
-  buyCFT20(listingHash: string) {
+  buy(listingHash: string, buyType: BuyType) {
     const params: MetaProtocolParams = [['h', listingHash]]
-    return buildOperation(this, this.fee, this.chainId, 'buy.cft20', params)
+    return buildOperation(
+      this,
+      this.fee,
+      this.chainId,
+      `buy.${buyType}`,
+      params,
+    )
   }
 }

--- a/client/src/metaprotocol/meta.ts
+++ b/client/src/metaprotocol/meta.ts
@@ -1,0 +1,27 @@
+import {
+  BaseProtocol,
+  MetaProtocolParams,
+  ProtocolFee,
+  buildOperation,
+} from './index.js'
+
+const DEFAULT_FEE: ProtocolFee = {
+  ibcChannel: 'channel-569',
+  receiver: 'cosmos1y6338yfh4syssaglcgh3ved9fxhfn0jk4v8qtv',
+  denom: 'uatom',
+  operations: {},
+}
+
+export default class MetaProtocol extends BaseProtocol {
+  version = 'v1'
+  name = 'meta'
+
+  constructor(chainId: string, fee: ProtocolFee = DEFAULT_FEE) {
+    super(chainId, fee)
+  }
+
+  execute() {
+    const params: MetaProtocolParams = []
+    return buildOperation(this, this.fee, this.chainId, 'execute', params)
+  }
+}

--- a/client/src/operations/cft20.ts
+++ b/client/src/operations/cft20.ts
@@ -1,5 +1,5 @@
 import CFT20Protocol from '../metaprotocol/cft20.js'
-import { OperationsBase } from './index.js'
+import { OperationsBase, Options, getDefaultOptions } from './index.js'
 
 interface DeployParams {
   name: string
@@ -10,18 +10,26 @@ interface DeployParams {
   openTime: Date
 }
 
-export class CFT20Operations extends OperationsBase {
+export class CFT20Operations<
+  T extends boolean = false,
+> extends OperationsBase<T> {
   protocol: CFT20Protocol
   address: string
+  options: Options<T>
 
-  constructor(chainId: string, address: string) {
+  constructor(
+    chainId: string,
+    address: string,
+    options: Options<T> = getDefaultOptions(),
+  ) {
     super()
     this.protocol = new CFT20Protocol(chainId)
     this.address = address
+    this.options = options
   }
 
   deploy(data: string | Buffer, mime: string, params: DeployParams) {
-    const inscription = this.protocol.createLogoInscription(
+    const inscriptionContent = this.protocol.createLogoInscription(
       this.address,
       data,
       mime,
@@ -34,7 +42,7 @@ export class CFT20Operations extends OperationsBase {
       params.mintLimit,
       params.openTime,
     )
-    return this.prepareOperation(operation, inscription)
+    return this.prepareOperation(operation, inscriptionContent)
   }
 
   mint(ticker: string, amount: number) {

--- a/client/src/operations/inscription.ts
+++ b/client/src/operations/inscription.ts
@@ -3,16 +3,24 @@ import InscriptionProtocol, {
   Parent,
   accountIdentifier,
 } from '../metaprotocol/inscription.js'
-import { OperationsBase } from './index.js'
+import { OperationsBase, Options, getDefaultOptions } from './index.js'
 
-export class InscriptionOperations extends OperationsBase {
+export class InscriptionOperations<
+  T extends boolean = false,
+> extends OperationsBase<T> {
   protocol: InscriptionProtocol
   address: string
+  options: Options<T>
 
-  constructor(chainId: string, address: string) {
+  constructor(
+    chainId: string,
+    address: string,
+    options: Options<T> = getDefaultOptions(),
+  ) {
     super()
     this.protocol = new InscriptionProtocol(chainId)
     this.address = address
+    this.options = options
   }
 
   inscribe<T = ContentMetadata>(
@@ -24,9 +32,13 @@ export class InscriptionOperations extends OperationsBase {
       parent = accountIdentifier(this.address)
     }
 
-    const inscription = this.protocol.createInscription(data, metadata, parent)
-    const operation = this.protocol.inscribe(inscription.hash)
-    return this.prepareOperation(operation, inscription)
+    const inscriptionContent = this.protocol.createInscriptionContent(
+      data,
+      metadata,
+      parent,
+    )
+    const operation = this.protocol.inscribe(inscriptionContent.hash)
+    return this.prepareOperation(operation, inscriptionContent)
   }
 
   transfer(hash: string, destination: string) {

--- a/client/src/operations/marketplace.ts
+++ b/client/src/operations/marketplace.ts
@@ -2,22 +2,27 @@ import { TOKEN_DECIMALS } from '../constants.js'
 import { createSendMessage } from '../helpers/msg.js'
 import MarketplaceProtocol from '../metaprotocol/marketplace.js'
 import { AsteroidService } from '../service/asteroid.js'
-import { OperationsBase } from './index.js'
+import { OperationsBase, Options, getDefaultOptions } from './index.js'
 
-export class MarketplaceOperations extends OperationsBase {
+export class MarketplaceOperations<
+  T extends boolean = false,
+> extends OperationsBase<T> {
   protocol: MarketplaceProtocol
   asteroidService: AsteroidService
   address: string
+  options: Options<T>
 
   constructor(
     chainId: string,
     address: string,
     asteroidService: AsteroidService,
+    options: Options<T> = getDefaultOptions(),
   ) {
     super()
     this.protocol = new MarketplaceProtocol(chainId)
     this.address = address
     this.asteroidService = asteroidService
+    this.options = options
   }
 
   listCFT20(

--- a/client/src/operations/meta.ts
+++ b/client/src/operations/meta.ts
@@ -1,0 +1,32 @@
+import MetaProtocol from '../metaprotocol/meta.js'
+import { TxData, TxInscription, prepareTx } from '../metaprotocol/tx.js'
+import { OperationsBase, Options, getDefaultOptions } from './index.js'
+
+export class MetaOperations<
+  T extends boolean = false,
+> extends OperationsBase<T> {
+  protocol: MetaProtocol
+  address: string
+  options: Options<T>
+
+  constructor(
+    chainId: string,
+    address: string,
+    options: Options<T> = getDefaultOptions(),
+  ) {
+    super()
+    this.protocol = new MetaProtocol(chainId)
+    this.address = address
+    this.options = options
+  }
+
+  execute(inscriptions: TxInscription[]): TxData {
+    const operation = this.protocol.execute()
+    return prepareTx(
+      this.address,
+      operation.urn,
+      inscriptions,
+      this.options.useIbc,
+    )
+  }
+}


### PR DESCRIPTION
1. Add an option to create a transaction with multiple inscription operations

    ```typescript
    const meta = new MetaOperations(
      context.network.chainId,
      context.account.address,
    )
    const inscriptionOps = new InscriptionOperations(
      context.network.chainId,
      context.account.address,
      { multi: true },
    )
    return meta.execute([
      inscriptionOps.transfer(
        '4C79CA69034AB97A49581E56FDE376E10D9FFB3E71567C0462A3729DA1B04E60',
        'cosmos10h9stc5v6ntgeygf5xf945njqq5h32r53uquvw',
      ),
      inscriptionOps.transfer(
        '7105307B313A509C67CF1C146576E881E4B20FBA487A31F8F0145BEACDDF9B73',
        'cosmos10h9stc5v6ntgeygf5xf945njqq5h32r53uquvw',
      ),
    ])
    ```

    Indexer support: https://github.com/astroport-fi/asteroid-protocol/pull/51

2. Add support for the inscription marketplace
3. Fix useIbc option