### PR TITLE
fix: force cosmoskit to use rpc and rest endpoints from env variables

### DIFF
--- a/app/app/context/wallet.tsx
+++ b/app/app/context/wallet.tsx
@@ -134,7 +134,17 @@ const MyModal = ({ isOpen, setOpen, walletRepo }: WalletModalProps) => {
   )
 }
 
-export default function WalletProvider() {
+export interface WalletProviderProps {
+  chainName: string
+  rpcEndpoint: string
+  restEndpoint: string
+}
+
+export default function WalletProvider({
+  chainName,
+  rpcEndpoint,
+  restEndpoint,
+}: WalletProviderProps) {
   return (
     <ChainProvider
       chains={getChains()}
@@ -143,6 +153,15 @@ export default function WalletProvider() {
       wallets={[...keplr, ...leap]}
       walletModal={MyModal}
       sessionOptions={{ duration: Math.pow(2, 31) - 1 }}
+      endpointOptions={{
+        isLazy: true,
+        endpoints: {
+          [chainName]: {
+            rpc: [rpcEndpoint],
+            rest: [restEndpoint],
+          },
+        },
+      }}
       // walletConnectOptions={{
       //   signClient: {
       //     projectId: 'a8510432ebb71e6948cfd6cde54b70f7',

--- a/app/app/root.tsx
+++ b/app/app/root.tsx
@@ -20,7 +20,7 @@ import { clientOnly$, serverOnly$ } from 'vite-env-only'
 import styles from '~/tailwind.css?url'
 import { AsteroidClient } from './api/client'
 import { RootContext } from './context/root'
-import WalletProvider from './context/wallet'
+import WalletProvider, { WalletProviderProps } from './context/wallet'
 import error404Image from '~/images/background/404.png'
 import error503Image from '~/images/background/503.png'
 
@@ -53,16 +53,18 @@ export async function loader({ context }: LoaderFunctionArgs) {
   })
 }
 
-function WalletProviderWrapper() {
+function WalletProviderWrapper(props: WalletProviderProps) {
   let Provider: JSX.Element | undefined
 
-  Provider = import.meta.env.DEV ? serverOnly$(<WalletProvider />) : undefined
+  Provider = import.meta.env.DEV
+    ? serverOnly$(<WalletProvider {...props} />)
+    : undefined
 
   if (Provider) {
     return Provider
   }
 
-  Provider = clientOnly$(<WalletProvider />)
+  Provider = clientOnly$(<WalletProvider {...props} />)
   if (Provider) {
     return Provider
   }
@@ -161,7 +163,11 @@ export default function App() {
             },
           }}
         >
-          <WalletProviderWrapper />
+          <WalletProviderWrapper
+            chainName={data.ENV.CHAIN_NAME}
+            rpcEndpoint={data.ENV.RPC}
+            restEndpoint={data.ENV.REST}
+          />
         </RootContext.Provider>
         <ScrollRestoration />
         <Scripts />


### PR DESCRIPTION
- force cosmoskit to use rpc and rest endpoints from env variables
- disable cosmos directory endpoints validation